### PR TITLE
Added Argentina Feeds

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -157,6 +157,44 @@
       "https://www.xlr8yourmac.com/news.xml"
     ]
   },
+  "Argentina": {
+    "category_type": "country",
+    "source_language": "es",
+    "display_names": {
+      "en": "Argentina",
+      "es": "Argentina"
+    },
+    "feeds": [
+      "https://www.lanacion.com.ar/feed",
+      "https://www.clarin.com/rss/",
+      "https://www.ambito.com/rss",
+      "https://www.infobae.com/rss/",
+      "https://www.pagina12.com.ar/rss",
+      "https://www.perfil.com/rss",
+      "https://www.telam.com.ar/rss",
+      "https://tn.com.ar/rss/",
+      "https://www.cronista.com/rss",
+      "https://www.lavoz.com.ar/rss",
+      "https://www.ellitoral.com/rss",
+      "https://www.rionegro.com.ar/rss",
+      "https://www.lacapital.com.ar/rss",
+      "https://www.mdzol.com/rss",
+      "https://www.losandes.com.ar/rss",
+      "https://www.eltribuno.com/rss",
+      "https://www.diariouno.com.ar/rss",
+      "https://www.0221.com.ar/rss",
+      "https://www.eldia.com/rss",
+      "https://www.eldiariodemadryn.com/rss",
+      "https://www.lmneuquen.com/rss",
+      "https://www.contexto.com.ar/rss",
+      "https://www.eldiaonline.com/rss",
+      "https://www.lanueva.com/rss",
+      "https://www.labrujula24.com/rss",
+      "https://www.elancasti.com.ar/rss",
+      "https://www.lagaceta.com.ar/rss",
+      "https://www.nuevodiarioweb.com.ar/rss"
+    ]
+  },
   "Australia": {
     "category_type": "topic",
     "source_language": "en",


### PR DESCRIPTION
Added a new 'Argentina' category to kite_feeds.json with 28 high-quality RSS feeds from reputable Argentinian news outlets including national sources (La Nación, Clarín, Infobae, Ámbito, Página/12, Perfil, Télam, TN, Cronista) and regional sources (La Voz, El Litoral, Río Negro, La Capital, MDZ, Los Andes, El Tribuno, and others).